### PR TITLE
Add script to initialize a Nitrokey HOTP secret to specific counter

### DIFF
--- a/nitrokey_hotp_initialize
+++ b/nitrokey_hotp_initialize
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+usage()
+{
+ echo "This command initializes the Nitrokey HOTP counter to the specified value"
+ echo "usage: $0 <nitrokey_admin_pin> <HOTP_secret> <HOTP_counter>"
+}
+
+if [ "$3" == "" ]; then
+  usage
+  exit 1
+fi
+
+PIN=$1
+SECRET=$2
+COUNTER=$3
+SECRET_B32=$(echo -n $SECRET | base32)
+
+echo nitrokey_hotp_verification set $SECRET_B32 $PIN 
+nitrokey_hotp_verification set $SECRET_B32 $PIN 
+if [ $? -ne 0 ]; then
+  echo "ERROR: Setting HOTP secret on Nitrokey failed!"
+  exit 1
+fi
+
+i=9
+while [ "$i" -lt "$COUNTER" ]; do
+  echo "Updating counter to $i"
+  HOTP_CODE=$(echo $SECRET | hotp $i)
+  nitrokey_hotp_verification check $HOTP_CODE > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "HOTP check failed for counter=$i, code=$HOTP_CODE"
+    exit 1
+  fi
+  let "i += 10"
+done
+
+HOTP_CODE=$(echo $SECRET | hotp $COUNTER)
+nitrokey_hotp_verification check $HOTP_CODE > /dev/null
+if [ $? -ne 0 ]; then
+  echo "HOTP check failed for counter=$COUNTER, code=$HOTP_CODE"
+  exit 1
+else
+  echo "Nitrokey initialized at counter $COUNTER"
+fi


### PR DESCRIPTION
Normally when one sets up the Nitrokey HOTP secret the assumption is
that the counter starts at zero. However in the case of using a counter
from a TPM, new counters are initialized at the value of the last
counter plus one. This means we need to synchronize the Nitrokey counter
with the TPM counter before we can use it.

This script takes advantage of the fact that the Nitrokey accepts the
next ten HOTP values in a list and then sets the Nitrokey counter to
that value, so the script "hops" ahead up until the point that the
Nitrokey counter matches the specified counter.