### PR TITLE
Making patch in Heads unnecessary by adapting changes

### DIFF
--- a/libremkey_hotp_initialize
+++ b/libremkey_hotp_initialize
@@ -14,9 +14,9 @@ fi
 PIN=$1
 SECRET=$2
 COUNTER=$3
-SECRET_B32=$(echo -n $SECRET | base32)
+SECRET_B32=$(cat $SECRET | base32)
 
-libremkey_hotp_verification set $SECRET_B32 $PIN 
+libremkey_hotp_verification set $SECRET_B32 "$PIN"
 if [ $? -ne 0 ]; then
   echo "ERROR: Setting HOTP secret on Librem Key failed!"
   exit 1
@@ -25,7 +25,7 @@ fi
 i=9
 while [ "$i" -lt "$COUNTER" ]; do
   echo "Updating counter to $i"
-  HOTP_CODE=$(echo $SECRET | hotp $i)
+  HOTP_CODE=$(hotp $i < $SECRET)
   libremkey_hotp_verification check $HOTP_CODE > /dev/null
   if [ $? -ne 0 ]; then
     echo "HOTP check failed for counter=$i, code=$HOTP_CODE"
@@ -34,7 +34,7 @@ while [ "$i" -lt "$COUNTER" ]; do
   let "i += 10"
 done
 
-HOTP_CODE=$(echo $SECRET | hotp $COUNTER)
+HOTP_CODE=$(hotp $i < $SECRET)
 libremkey_hotp_verification check $HOTP_CODE > /dev/null
 if [ $? -ne 0 ]; then
   echo "HOTP check failed for counter=$COUNTER, code=$HOTP_CODE"

--- a/nitrokey_hotp_initialize
+++ b/nitrokey_hotp_initialize
@@ -14,9 +14,9 @@ fi
 PIN=$1
 SECRET=$2
 COUNTER=$3
-SECRET_B32=$(echo -n $SECRET | base32)
+SECRET_B32=$(cat $SECRET | base32)
 
-nitrokey_hotp_verification set $SECRET_B32 $PIN 
+nitrokey_hotp_verification set $SECRET_B32 "$PIN"
 if [ $? -ne 0 ]; then
   echo "ERROR: Setting HOTP secret on Nitrokey failed!"
   exit 1
@@ -25,7 +25,7 @@ fi
 i=9
 while [ "$i" -lt "$COUNTER" ]; do
   echo "Updating counter to $i"
-  HOTP_CODE=$(echo $SECRET | hotp $i)
+  HOTP_CODE=$(hotp $i < $SECRET)
   nitrokey_hotp_verification check $HOTP_CODE > /dev/null
   if [ $? -ne 0 ]; then
     echo "HOTP check failed for counter=$i, code=$HOTP_CODE"
@@ -34,7 +34,7 @@ while [ "$i" -lt "$COUNTER" ]; do
   let "i += 10"
 done
 
-HOTP_CODE=$(echo $SECRET | hotp $COUNTER)
+HOTP_CODE=$(hotp $i < $SECRET)
 nitrokey_hotp_verification check $HOTP_CODE > /dev/null
 if [ $? -ne 0 ]; then
   echo "HOTP check failed for counter=$COUNTER, code=$HOTP_CODE"


### PR DESCRIPTION
This PR shall make [this patchfile in Heads](https://github.com/osresearch/heads/blob/3dbf1f5f39ab9a8965ac89b20d1ef7969a7da5e8/patches/libremkey-hotp-verification-e5fa36a7a1950226d0ef94e2eeed0ffb510eba89.patch) unnecessary. The changes can be included in nitrokey-hotp-verification right away.

The patch in Heads still has a bigger part for the ToolchainMakefile, but the patch is currently not applied, because the patch wasn't renamed during [this commit](https://github.com/osresearch/heads/commit/2d50e01071f43d0db9995320fb2f6ff6c810bbc9). We might include the Makefile stuff here as well, to get rid of the patchfile and the need to adapt it every time we need to update nitrokey-hotp-verification.

@szszszsz please have a look if this can be included in your heads specific makefile (if not done already anyways).