### PR TITLE
main.c: remove output when RET_NO_PIN_ATTEMPTS (no PIN retry counter) is true

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -110,8 +110,6 @@ int parse_cmd_and_run(int argc, char *const *argv) {
                     if (res != RET_NO_PIN_ATTEMPTS) {
                         printf("\tCard counters: Admin %d, User %d\n",
                                status.retry_admin, status.retry_user);
-                    } else {
-                        printf("\tCard counters: PIN is not set - set PIN before the first use\n");
                     }
                 }
                 if (res == RET_NO_PIN_ATTEMPTS) {


### PR DESCRIPTION
The dongle is in a clean state here without bad PIN entered (when RET_NO_PIN_ATTEMPTS is true). 
This doesn't imply that we are using the default PINS.

---

This seems to have been based on wrong assumption that if no prior PIN attempt we are in factory state with default PINS (USER 123456, ADMIN 12345678). Calling code should be, and is responsible of interpreting artifacts telling that the USB Security dongle is not in factory reset mode with default PINS.

Fixes #30 

---

History:

Prior of https://github.com/linuxboot/heads/commit/99673d373d1353ed785874735741568aadf0a175, Heads was doing the same wrong assumption. Heads was consuming 1/3 of the PIN to check if it was the default one without, resulting with the user only having 2/3 PIN input attempts before being locked out.

Because of https://github.com/Nitrokey/nitrokey-pro-firmware/issues/54 (unfixed, linking to unfixed https://github.com/Nitrokey/libnitrokey/issues/137), if Heads attempts to use scdaemon/libnitrokey, the dongle hangs. Let if be libnitrokey/gpg expecting exclusive dongle access, this cause hangs.

Therefore https://github.com/linuxboot/heads/commit/99673d373d1353ed785874735741568aadf0a175 bases its assumptions on Heads previously created gpg keyring without relaying on neither scdaemon/libnitrokey. It uses public key creation vs current timsetamp to determine if the user should be reminded that is using default PINs, they should be changed.

TODO:
- Fix https://github.com/Nitrokey/nitrokey-pro-firmware/issues/54
- Fix https://github.com/Nitrokey/libnitrokey/issues/137

Otherwise, if on any situation, libnitrokey/scdaemon operations are intertwined, this causes https://github.com/Nitrokey/heads/issues/48, which i'll reopen.

Any Heads developer will come to the same problems:
- Develop on host. Push signed commits with said dongle, which use scdaemon on host to interact with USB Security dongle to do signing ops.
- Call make BOARD=qemu-coreboot-fbwhiptail-tpm2-hotp USB_TOKEN=NitrokeyPro/NitrokeyStorage/Nitrokey3NFC/LibremKey to test Heads.
- Land under kvm/qemu, observe reported locked problems, blame QubesOS, blame Heads, blame gnupg.
- Truth is that its libnitrokey/firmware bug.

----

hotp-verification should only report on : firmware version(currently wrong), serial number and success/fail state and not do any assumption reporting false information, confusing the end user.