### PR TITLE
Check secrets app PIN before setting the new reverse hotp credential

### DIFF
--- a/src/operations.c
+++ b/src/operations.c
@@ -27,6 +27,7 @@
 #include "min.h"
 #include "operations_ccid.h"
 #include "random_data.h"
+#include "return_codes.h"
 #include "settings.h"
 #include "structs.h"
 #include "utils.h"
@@ -71,7 +72,8 @@ int set_secret_on_device(struct Device *dev, const char *OTP_secret_base32, cons
             check_ret(authenticate_ccid(dev, admin_PIN), RET_WRONG_PIN);
         }
 #endif
-        return set_secret_on_device_ccid(dev, OTP_secret_base32, hotp_counter);
+
+        return set_secret_on_device_ccid(dev, admin_PIN, OTP_secret_base32, hotp_counter);
     }
 
 

--- a/src/operations_ccid.h
+++ b/src/operations_ccid.h
@@ -7,7 +7,8 @@
 
 int set_pin_ccid(struct Device *dev, const char *admin_PIN);
 int authenticate_ccid(struct Device *dev, const char *admin_PIN);
-int set_secret_on_device_ccid(struct Device *dev, const char *OTP_secret_base32, const uint64_t hotp_counter);
+int authenticate_or_set_ccid(struct Device *dev, const char *admin_PIN);
+int set_secret_on_device_ccid(struct Device *dev, const char *admin_PIN, const char *OTP_secret_base32, const uint64_t hotp_counter);
 int verify_code_ccid(struct Device *dev, const uint32_t code_to_verify);
 int status_ccid(libusb_device_handle *handle, int *attempt_counter, uint16_t *firmware_version, uint32_t *serial_number);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,7 +44,10 @@
 // #define FEATURE_CCID_ASK_FOR_PIN_ON_ERROR
 
 // Use the provided PIN for authentication over CCID
-// #define CCID_AUTHENTICATE
+// #define CCID_AUTHENTICATE 
+
+// Attempt to authenticate before setting the PIN, if no pin is present, create the PIN
+#define CCID_SECRETS_AUTHENTICATE_OR_CREATE_PIN
 
 // Allow CCID use
 #define FEATURE_USE_CCID


### PR DESCRIPTION
If the PIN is not set, configure it.

Nitrokeys prior to https://github.com/Nitrokey/trussed-secrets-app/pull/114 will ignore the PIN. It might surprise users that have not set a PIN in the past that a PIN is now set.

Nitrokeys with firmware after https://github.com/Nitrokey/trussed-secrets-app/pull/114 will accept expect this behaviour from hotp-verification