### PR TITLE
Add support for nitrokey 3 distinction between the secrets app firmware and the device firmware versions

### DIFF
--- a/src/ccid.c
+++ b/src/ccid.c
@@ -104,7 +104,7 @@ IccResult parse_icc_result(uint8_t *buf, size_t buf_len) {
             //            .buffer_len = buf_len
     };
     // Make sure the response do not contain overread attempts
-    rassert(i.data_len < buf_len - 10);
+    rassert(i.data_len <= buf_len - 10);
     return i;
 }
 
@@ -307,6 +307,75 @@ int send_select_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_siz
     return RET_NO_ERROR;
 }
 
+int send_select_nk3_admin_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_size, IccResult *iccResult) {
+    unsigned char cmd_select[] = {
+            0x6f,
+            0x0E,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xa4,
+            0x04,
+            0x00,
+            0x09,
+            0xa0,
+            0x00,
+            0x00,
+            0x08,
+            0x47,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+    };
+
+    check_ret(
+            ccid_process_single(handle, buf, buf_size, cmd_select, sizeof cmd_select, iccResult),
+            RET_COMM_ERROR);
+
+
+    return RET_NO_ERROR;
+}
+
+int send_select_nk3_pgp_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_size, IccResult *iccResult) {
+    unsigned char cmd_select[] = {
+            0x6f,
+            0x0C,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xA4,
+            0x04,
+            0x00,
+            0x06,
+            0xD2,
+            0x76,
+            0x00,
+            0x01,
+            0x24,
+            0x01,
+            0x00,
+    };
+
+    check_ret(
+            ccid_process_single(handle, buf, buf_size, cmd_select, sizeof cmd_select, iccResult),
+            RET_COMM_ERROR);
+
+
+    return RET_NO_ERROR;
+}
 
 int ccid_init(libusb_device_handle *handle) {
 

--- a/src/ccid.h
+++ b/src/ccid.h
@@ -70,6 +70,8 @@ uint32_t icc_pack_tlvs_for_sending(uint8_t *buf, size_t buflen, TLV tlvs[], int 
 libusb_device_handle *get_device(libusb_context *ctx, const struct VidPid pPid[], int devices_count);
 int ccid_init(libusb_device_handle *handle);
 int send_select_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_size, IccResult *iccResult);
+int send_select_nk3_admin_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_size, IccResult *iccResult);
+int send_select_nk3_pgp_ccid(libusb_device_handle *handle, uint8_t buf[], size_t buf_size, IccResult *iccResult);
 
 
 enum {

--- a/src/device.h
+++ b/src/device.h
@@ -72,7 +72,7 @@ struct Device {
 
 int device_connect(struct Device *dev);
 int device_disconnect(struct Device *dev);
-int device_get_status(struct Device *dev, struct ResponseStatus *out_status);
+int device_get_status(struct Device *dev, struct FullResponseStatus *out_status);
 int device_send(struct Device *dev, uint8_t *in_data, size_t data_size, uint8_t command_ID);
 int device_receive(struct Device *dev, uint8_t *out_data, size_t out_buffer_size);
 int device_send_buf(struct Device *dev, uint8_t command_ID);

--- a/src/operations_ccid.h
+++ b/src/operations_ccid.h
@@ -10,7 +10,7 @@ int authenticate_ccid(struct Device *dev, const char *admin_PIN);
 int authenticate_or_set_ccid(struct Device *dev, const char *admin_PIN);
 int set_secret_on_device_ccid(struct Device *dev, const char *admin_PIN, const char *OTP_secret_base32, const uint64_t hotp_counter);
 int verify_code_ccid(struct Device *dev, const uint32_t code_to_verify);
-int status_ccid(libusb_device_handle *handle, int *attempt_counter, uint16_t *firmware_version, uint32_t *serial_number);
+int status_ccid(libusb_device_handle *handle, struct FullResponseStatus *full_response);
 
 
 #endif//NITROKEY_HOTP_VERIFICATION_OPERATIONS_CCID_H

--- a/src/structs.h
+++ b/src/structs.h
@@ -116,6 +116,25 @@ struct ResponseStatus {
     uint8_t retry_user;  /*not present in the firmware response for the Status command in v0.8 firmware*/
 };
 
+enum DeviceType {
+  Unknown = 0,
+  Nk3,
+  NkPro2,  
+  NkStorage,
+  LibremKey,
+};
+
+struct FullResponseStatus {
+    enum DeviceType device_type;
+    struct ResponseStatus response_status;
+    struct {
+        // Only valid if device_type is NK3
+        uint8_t pgp_admin_pin_retries;    
+        uint8_t pgp_user_pin_retries;    
+        uint32_t firmware_version;
+    } nk3_extra_info;
+};
+
 
 struct WriteToOTPSlot {
     //admin auth


### PR DESCRIPTION
Fix #38 