### PR TITLE
Add reset command for nitrokey 3

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 
 #include "ccid.h"
 #include "operations.h"
+#include "operations_ccid.h"
 #include "return_codes.h"
 #include "utils.h"
 #include "operations_ccid.h"
@@ -161,8 +162,13 @@ int parse_cmd_and_run(int argc, char *const *argv) {
                 }
                 break;
             case 'r':
-                if (argc != 3) break;
-                res = regenerate_AES_key(&dev, argv[2]);
+                if (strncmp(argv[1], "reset", 15) == 0) {
+                    if (argc != 2) break;
+                    res = nk3_reset(&dev);
+                } else if (strncmp(argv[1], "regenerate", 15) == 0) {
+                    if (argc != 3) break;
+                    res = regenerate_AES_key(&dev, argv[2]);
+                }
                 break;
             default:
                 break;

--- a/src/main.c
+++ b/src/main.c
@@ -41,8 +41,11 @@ void print_help(char *app_name) {
            "\t%s check <HOTP CODE>\n"
            "\t%s regenerate <ADMIN PIN>\n"
            "\t%s set <BASE32 HOTP SECRET> <ADMIN PIN> [COUNTER]\n"
-           "\t%s nk3-change-pin <old-pin> <new-pin>\n",
-           app_name, app_name, app_name, app_name, app_name, app_name, app_name);
+           "\t%s nk3-change-pin <old-pin> <new-pin>\n"
+           "\t%s reset [ADMIN PIN]\n"
+           "\t%s regenerate\n"
+           "\t%s set <BASE32 HOTP SECRET> <ADMIN PIN> [COUNTER]\n",
+           app_name, app_name, app_name, app_name, app_name, app_name, app_name, app_name, app_name, app_name);
 }
 
 
@@ -163,8 +166,8 @@ int parse_cmd_and_run(int argc, char *const *argv) {
                 break;
             case 'r':
                 if (strncmp(argv[1], "reset", 15) == 0) {
-                    if (argc != 2) break;
-                    res = nk3_reset(&dev);
+                    if (argc != 2 && argc != 3) break;
+                    res = nk3_reset(&dev, argc == 3 ? argv[2]: NULL);
                 } else if (strncmp(argv[1], "regenerate", 15) == 0) {
                     if (argc != 3) break;
                     res = regenerate_AES_key(&dev, argv[2]);

--- a/src/operations_ccid.c
+++ b/src/operations_ccid.c
@@ -36,6 +36,12 @@
 int nk3_reset(struct Device *dev, const char * new_pin) {
     libusb_device *usb_dev;
     struct libusb_device_descriptor usb_desc;
+
+    if (!dev->mp_devhandle_ccid) {
+        // Not an NK3
+        return RET_NO_ERROR;
+    }
+    
     usb_dev = libusb_get_device(dev->mp_devhandle_ccid);
 
     int r = libusb_get_device_descriptor(usb_dev, &usb_desc);
@@ -46,7 +52,7 @@ int nk3_reset(struct Device *dev, const char * new_pin) {
 
 
     if (usb_desc.idVendor != NITROKEY_USB_VID || usb_desc.idProduct != NITROKEY_3_USB_PID) {
-        return 0;
+        return RET_NO_ERROR;
     }
 
 

--- a/src/operations_ccid.c
+++ b/src/operations_ccid.c
@@ -33,7 +33,7 @@
 
 
 
-int nk3_reset(struct Device *dev) {
+int nk3_reset(struct Device *dev, const char * new_pin) {
     libusb_device *usb_dev;
     struct libusb_device_descriptor usb_desc;
     usb_dev = libusb_get_device(dev->mp_devhandle_ccid);
@@ -68,6 +68,10 @@ int nk3_reset(struct Device *dev) {
     // check status code
     if (iccResult.data_status_code != 0x9000) {
         return 1;
+    }
+
+    if (new_pin != NULL) {
+        set_pin_ccid(dev, new_pin);
     }
 
     return RET_NO_ERROR;

--- a/src/operations_ccid.c
+++ b/src/operations_ccid.c
@@ -39,6 +39,7 @@ int nk3_reset(struct Device *dev, const char * new_pin) {
 
     if (!dev->mp_devhandle_ccid) {
         // Not an NK3
+        printf("No Nitrokey 3 found. No operation performed\n");
         return RET_NO_ERROR;
     }
     
@@ -52,6 +53,7 @@ int nk3_reset(struct Device *dev, const char * new_pin) {
 
 
     if (usb_desc.idVendor != NITROKEY_USB_VID || usb_desc.idProduct != NITROKEY_3_USB_PID) {
+        printf("No Nitrokey 3 found. No operation performed\n");
         return RET_NO_ERROR;
     }
 

--- a/src/operations_ccid.h
+++ b/src/operations_ccid.h
@@ -12,6 +12,7 @@ int set_secret_on_device_ccid(struct Device *dev, const char *admin_PIN, const c
 int verify_code_ccid(struct Device *dev, const uint32_t code_to_verify);
 int status_ccid(libusb_device_handle *handle, struct FullResponseStatus *full_response);
 int nk3_change_pin(struct Device *dev, const char *old_pin, const char*new_pin);
+int nk3_reset(struct Device *dev);
 
 
 #endif//NITROKEY_HOTP_VERIFICATION_OPERATIONS_CCID_H

--- a/src/operations_ccid.h
+++ b/src/operations_ccid.h
@@ -12,7 +12,10 @@ int set_secret_on_device_ccid(struct Device *dev, const char *admin_PIN, const c
 int verify_code_ccid(struct Device *dev, const uint32_t code_to_verify);
 int status_ccid(libusb_device_handle *handle, struct FullResponseStatus *full_response);
 int nk3_change_pin(struct Device *dev, const char *old_pin, const char*new_pin);
-int nk3_reset(struct Device *dev);
+// new_pin can be `null`
+//
+// If it is, no new pin will be set
+int nk3_reset(struct Device *dev, const char * new_pin);
 
 
 #endif//NITROKEY_HOTP_VERIFICATION_OPERATIONS_CCID_H


### PR DESCRIPTION
Close https://github.com/Nitrokey/nitrokey-hotp-verification/issues/42


```
./hotp_verification reset
```

Is a noop on a device other than NK3. On an NK3, reset the secrets app and thus the HOTP code.