### PR TITLE
CCID: Remove touch received info output

### DIFF
--- a/src/ccid.c
+++ b/src/ccid.c
@@ -223,11 +223,6 @@ int ccid_process_single(libusb_device_handle *handle, uint8_t *receiving_buffer,
                 fflush(stdout);
             }
             continue;
-        } else {
-            if (prev_status == AWAITING_FOR_TOUCH_STATUS_CODE) {
-                printf(". touch received\n");
-                fflush(stdout);
-            }
         }
         prev_status = iccResult.status;
         if (iccResult.chain == 0 || iccResult.chain == 2) {


### PR DESCRIPTION
The current way is not valid, as the output is only for wait extensions, and not for touch information.

There's also no way to distinguish an error from a correct touch received from the CCID layer.

It's better to remove this display

Fix #50 